### PR TITLE
Changes in gcov 4.7 output format

### DIFF
--- a/src/GCovParser.py
+++ b/src/GCovParser.py
@@ -29,7 +29,7 @@ class GCDAData:
 ###
         
 kGCovFileRE = re.compile('^File \'([^\n]*)\'$', re.DOTALL|re.MULTILINE)
-kGCovFileAndOutputRE = re.compile('File \'([^\n]*)\'.*?:creating \'([^\n]*)\'',
+kGCovFileAndOutputRE = re.compile('File \'([^\n]*)\'.*?:?[cC]reating \'([^\n]*)\'',
                                   re.DOTALL|re.MULTILINE)
 
 def parseGCovFile(gcovPath, baseDir):


### PR DESCRIPTION
In gcov 4.7 (the current in debian-testing), the last line of running gcov is

```
Creating '#foo#bar'
```

instead of

```
foo.bar:creating '#foo#bar'
```

making the current regex fail to match and making zcov not find any files. This patch modifies the regex to work with both versions
