### PR TITLE
fixed a bug that cause zcov to crash when used with gcov v4.8

### DIFF
--- a/zcov/GCovParser.py
+++ b/zcov/GCovParser.py
@@ -162,8 +162,8 @@ def parseGCDA(gcdaPath,basePath=None):
 
     entries = []
     for res in kGCovFileAndOutputRE.finditer(data):
-        path,CreateRemove,output = res.groups()
-        if CreateRemove == "Removing":
+        path,createRemove,output = res.groups()
+        if createRemove == "Removing":
            continue
         path = os.path.realpath(path)
         entries.append((path, parseGCovFile(output, basePath)))

--- a/zcov/GCovParser.py
+++ b/zcov/GCovParser.py
@@ -29,7 +29,7 @@ class GCDAData:
 ###
         
 kGCovFileRE = re.compile('^File \'([^\n]*)\'$', re.DOTALL|re.MULTILINE)
-kGCovFileAndOutputRE = re.compile('File \'([^\n]*)\'.*?:?[cC]reating \'([^\n]*)\'',
+kGCovFileAndOutputRE = re.compile('File \'([^\n]*)\'.*?:?([cC]reating|Removing) \'([^\n]*)\'',
                                   re.DOTALL|re.MULTILINE)
 
 def parseGCovFile(gcovPath, baseDir):
@@ -162,7 +162,9 @@ def parseGCDA(gcdaPath,basePath=None):
 
     entries = []
     for res in kGCovFileAndOutputRE.finditer(data):
-        path,output = res.groups()
+        path,CreateRemove,output = res.groups()
+        if CreateRemove == "Removing":
+           continue
         path = os.path.realpath(path)
         entries.append((path, parseGCovFile(output, basePath)))
         os.remove(output)


### PR DESCRIPTION
With gcov v.4.8 they introduced removing files .gcov files if they are not executed. Here is an example of snippet of gcov output:

File '/usr/include/c++/4.8/bits/stl_iterator_base_funcs.h'
Lines executed:100.00% of 4
No branches
No calls
Creating 'FastCexSolver.gcno##stl_iterator_base_funcs.h.gcov'

File '/usr/include/c++/4.8/bits/stl_iterator_base_types.h'
No executable lines
No branches
No calls
Removing 'FastCexSolver.gcno##stl_iterator_base_types.h.gcov'

File '/usr/include/c++/4.8/bits/stl_map.h'
Lines executed:100.00% of 13
Branches executed:100.00% of 6
Taken at least once:83.33% of 6
Calls executed:100.00% of 3
Creating 'FastCexSolver.gcno##stl_map.h.gcov'

Currently the code does no deal with "Removing" keyword and that causes zcov to try to associate stl_iterator_base_types.h with FastCexSolver.gcno##stl_map.h.gcov (as that is the next Creating output of gcov). 

This fix just skips any such occurances